### PR TITLE
Shorten PROJECT_BRIEF to prevent overlap of search box in awesome documentation

### DIFF
--- a/docs/dime.doxygen.awesome.cmake.in
+++ b/docs/dime.doxygen.awesome.cmake.in
@@ -6,7 +6,7 @@
 DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = @PROJECT_NAME@
 PROJECT_NUMBER         = @PROJECT_VERSION@
-PROJECT_BRIEF          = "A library for reading, constructing, manipulating, and writing DXF file data"
+PROJECT_BRIEF          = "Portable DXF file library"
 PROJECT_LOGO           = @CMAKE_SOURCE_DIR@/docs/doxygen/Coin_logo.png
 PROJECT_ICON           =
 OUTPUT_DIRECTORY       =


### PR DESCRIPTION
Here you can see the problem:

![grafik](https://github.com/coin3d/dime/assets/4239304/2d5770c2-ee88-435c-a2d0-897c7ef3c00f)
